### PR TITLE
fix typo of soft_delete/1 with hard_delete/1

### DIFF
--- a/_posts/2019-2-21-soft-delete-with-ecto-3-and-postgres.md
+++ b/_posts/2019-2-21-soft-delete-with-ecto-3-and-postgres.md
@@ -169,7 +169,7 @@ affects how Ecto works, and you can see that by looking at that Repo. It's
 totally normal with the exception of that one additional function, and that
 function itself is fairly normal as well.
 
-What's going on in `soft_delete/1` is we have an `Ecto.Multi` operation, and the
+What's going on in `hard_delete/1` is we have an `Ecto.Multi` operation, and the
 first thing we do is to disable the Postgres trigger that we set to do soft
 deletes for us. Once that's disabled, we actually delete the record as we
 normally would, and once that's done we re-enable the trigger again so we go


### PR DESCRIPTION
Great article thanks for sharing! 

Re: 
> There are Reasons™ why that has to be an AFTER DELETE trigger instead of a BEFORE DELETE trigger, but they’re not too important, really, so I’ll spare you from having to read all of them.

I'd actually love to understand the reasons, even if you could point me to link(s) in the right direction.